### PR TITLE
Compatibility fixes

### DIFF
--- a/src/es6/events.js
+++ b/src/es6/events.js
@@ -14,6 +14,10 @@ function EventEmitter() {
 export default EventEmitter;
 export {EventEmitter};
 
+// nodejs oddity
+// require('events') === require('events').EventEmitter
+EventEmitter.EventEmitter = EventEmitter
+
 EventEmitter.usingDomains = false;
 
 EventEmitter.prototype.domain = undefined;

--- a/src/es6/http.js
+++ b/src/es6/http.js
@@ -157,3 +157,11 @@ export var STATUS_CODES = {
   510: 'Not Extended', // RFC 2774
   511: 'Network Authentication Required' // RFC 6585
 };
+
+export default {
+  request,
+  get,
+  Agent,
+  METHODS,
+  STATUS_CODES
+}


### PR DESCRIPTION
Fixes `var events = require('events').EventEmitter`

Fixes `var http = require('http')` warnings