### PR TITLE
Replace fs shim with browserfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "browserify-fs": "^1.0.0",
+    "browserfs": "^1.4.3",
     "buffer-es6": "^4.9.2",
     "crypto-browserify": "^3.11.0",
     "process-es6": "^0.11.2"

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ libs.set('tty', require.resolve(join('..', 'src', 'es6', 'tty')));
 libs.set('domain', require.resolve(join('..', 'src', 'es6', 'domain')));
 
 const CRYPTO_PATH = require.resolve('crypto-browserify');
-const FS_PATH = require.resolve('browserify-fs');
+const FS_PATH = require.resolve('browserfs/dist/shims/fs.js');
 const EMPTY_PATH = require.resolve(join('..', 'src', 'es6', 'empty'));
 
 // not shimmed

--- a/test/examples/fs.js
+++ b/test/examples/fs.js
@@ -1,0 +1,11 @@
+import fs from 'fs';
+
+if (
+  typeof fs.mkdir !== 'function'
+  || typeof fs.writeFile !== 'function'
+  || typeof fs.readFile !== 'function'
+) {
+  done(new Error('not right'));
+} else {
+  done();
+}

--- a/test/index.js
+++ b/test/index.js
@@ -65,4 +65,18 @@ describe('rollup-plugin-node-builtins', function() {
       done();
     });
   });
-})
+  it('fs option works', function(done) {
+    var config = {
+      entry: 'test/examples/fs.js',
+      plugins: [
+        builtins({ fs: true }),
+      ],
+    };
+    rollup.rollup(config).then(function() {
+      done();
+    }, function(err) {
+      debug(err);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
`browserify-fs` does not appear to be maintained anymore. This shim from `BrowserFS` seems to do the trick as a drop-in replacement.